### PR TITLE
Codeclimate - Ignore lib files

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,4 +3,8 @@ exclude_patterns:
 - "public/js/PLYLoader.js"
 - "public/js/STLLoader.js"
 - "public/js/three.min.js"
+- "public/js/OBJLoader.js"
+- "public/js/OBJLoader2.js"
+- "public/js/LoaderSupport.js"
+- "public/js/OutlinePass.js"
 - "db"


### PR DESCRIPTION
Ignored ThreeJS loaders and helpers which are used in the 3D viewer

Changed **${ROOT_PATH}**\.codeclimate.yml